### PR TITLE
Fix uninitialized variable when referencing keys by pageant.

### DIFF
--- a/windows/pageant.c
+++ b/windows/pageant.c
@@ -802,7 +802,7 @@ static int do_accept_agent_request(int type, const RSAKey *rsaKey, const ssh2_us
     }
 
     if (keyname != NULL) {
-        char *value;
+        char *value = NULL;
         if (get_use_inifile()) {
             value = get_ini_sz(APPNAME, keyname, inifile);
         } else {


### PR DESCRIPTION
## 概要

 * #5 の修正プルリクです。
 * issueの修正案に記載した、未初期化の変数を `NULL` で明示的に初期化する内容となっています。
   * Windows10とVisual Studio 2022 Communityで修正内容がビルドできることと、pageantがクラッシュせずに鍵を参照できるところまで確認済みです。
